### PR TITLE
Only fetch the SA key if it doesn't already exist

### DIFF
--- a/serviceaccounts.rb
+++ b/serviceaccounts.rb
@@ -17,8 +17,10 @@ class ServiceAccountContext
     ENV["GOOGLE_APPLICATION_CREDENTIALS"] = File.expand_path(SERVICE_ACCOUNT_KEY_PATH)
     common = Common.new
     if @project == "all-of-us-workbench-test"
-      common.run_inline %W{gsutil cp gs://#{@project}-credentials/app-engine-default-sa.json
+      unless File.exists?(SERVICE_ACCOUNT_KEY_PATH)
+        common.run_inline %W{gsutil cp gs://#{@project}-credentials/app-engine-default-sa.json
             #{SERVICE_ACCOUNT_KEY_PATH}}
+      end
       yield
     else
       service_account = "#{@project}@appspot.gserviceaccount.com"


### PR DESCRIPTION
Problem:
During local development, I often switch my auth'd user (`gcloud auth login`). Sometimes my dev cycle will involve running some gsutil commands as my fake-aou user, then changing some server code and relaunching. This results in massive churn of having to run `gcloud auth login` currently, as we currently localize the GAE SA key on every run.

In a follow-up PR to workbench, I will also delete the key during docker_clean, which should alleviate any potential issues if we decide to invalidate this key and need devs to pull a new one.

Also, please grant edit access to this repo.