### PR TITLE
remove dependency on project-management

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "utils"]
-	path = utils
-	url = https://github.com/dmohs/project-management.git

--- a/utils/.sample-project.rb
+++ b/utils/.sample-project.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+
+PROJECT_SCRIPTS_DIR = "libproject"
+
+unless Dir.exists? "#{PROJECT_SCRIPTS_DIR}/common"
+  unless system(*%W{mkdir -p #{PROJECT_SCRIPTS_DIR}})
+    STDERR.puts "mkdir failed."
+    exit 1
+  end
+  unless system(*%W{
+      git clone https://github.com/dmohs/project-management.git
+      #{PROJECT_SCRIPTS_DIR}/common
+    })
+    STDERR.puts "git clone failed."
+    exit 1
+  end
+end
+
+require_relative "#{PROJECT_SCRIPTS_DIR}/common/common"
+Dir.foreach(PROJECT_SCRIPTS_DIR) do |item|
+  unless item =~ /^\.\.?$/ || item == "common"
+    require_relative "#{PROJECT_SCRIPTS_DIR}/#{item}"
+  end
+end
+
+# Uncomment this line if using these tools as a submodule instead of a clone.
+# Common.unregister_upgrade_self_command
+
+c = Common.new
+
+if ARGV.length == 0 or ARGV[0] == "--help"
+  c.print_usage
+  exit 0
+end
+
+command = ARGV.first
+args = ARGV.drop(1)
+
+c.handle_or_die(command, *args)

--- a/utils/.sample-project.yaml
+++ b/utils/.sample-project.yaml
@@ -1,0 +1,6 @@
+namespace: somewebui
+source_file_paths:
+  - project.clj
+  - src/cljs
+static_file_src: src/static
+static_file_dest: resources/public

--- a/utils/LICENSE
+++ b/utils/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 David Mohs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,17 @@
+# Project Management Tools
+
+- I have some code in some language.
+- I need to perform various tasks with this code (e.g., compile, deploy).
+- I want to write scripts to do these tasks to make them easier and document them.
+- I do not want to write these scripts in bash.
+
+Enter this package. Start by:
+
+```bash
+curl https://raw.githubusercontent.com/dmohs/project-management/master/.sample-project.rb > project.rb && chmod +x project.rb
+```
+then:
+```bash
+./project.rb
+```
+Now add tasks to the `.project` folder a la https://github.com/dmohs/react-cljs/blob/master/.project/install.rb.

--- a/utils/common.rb
+++ b/utils/common.rb
@@ -1,0 +1,221 @@
+require "open3"
+require "ostruct"
+require "yaml"
+
+require_relative "dockerhelper"
+require_relative "syncfiles"
+
+class Common
+  @@commands = []
+
+  def self.register_command(command)
+    invocation = command[:invocation]
+    fn = command[:fn]
+    if fn.nil?
+      error "No :fn key defined for command #{invocation}"
+      exit 1
+    end
+    if fn.is_a?(Symbol)
+      unless Object.private_method_defined?(fn)
+        self.new.error "Function #{fn.to_s} is not defined for #{invocation}."
+        exit 1
+      end
+    else
+      # TODO(dmohs): Deprecation warning.
+      unless fn.is_a?(Proc)
+        self.new.error ":fn key for #{invocation} does not define a Proc or Symbol"
+        exit 1
+      end
+    end
+
+    @@commands.push(command)
+  end
+
+  def self.unregister_upgrade_self_command()
+    @@commands.reject! { |x| x[:upgrade_self_command] }
+  end
+
+  def self.commands()
+    @@commands
+  end
+
+  attr :docker
+  attr :sf
+
+  def initialize()
+    @docker = DockerHelper.new(self)
+    @sf = SyncFiles.new(self)
+  end
+
+  def print_usage()
+    STDERR.puts "\nUsage: ./project.rb <command> <options>\n\n"
+    STDERR.puts "COMMANDS\n\n"
+    @@commands.each do |command|
+      STDERR.puts bold_term_text(command[:invocation])
+      STDERR.puts command[:description] || "(no description specified)"
+      STDERR.puts
+    end
+  end
+
+  def handle_or_die(args)
+    if args.length == 0 or args[0] == "--help"
+      print_usage
+      exit 0
+    end
+
+    if args[0] == "--cmplt" # Shell completion argument name inspired by vault
+      # Form of args: --cmplt <index-of-current-argument> ./project.rb arg arg arg
+      index = args[1].to_i
+      word = args[2 + index]
+      puts @@commands.select{ |x| x[:invocation].start_with?(word) }
+          .map{ |x| x[:invocation]}.join("\n")
+      exit 0
+    end
+
+    command = args.first
+    handler = @@commands.select{ |x| x[:invocation] == command }.first
+    if handler.nil?
+      error "#{command} command not found."
+      exit 1
+    end
+
+    fn = handler[:fn]
+    if fn.is_a?(Symbol)
+      method(fn).call(*args)
+    else
+      handler[:fn].call(*args.drop(1))
+    end
+  end
+
+  def load_env()
+    if not File.exists?("project.yaml")
+      error "Missing project.yaml"
+      exit 1
+    end
+    OpenStruct.new YAML.load(File.read("project.yaml"))
+  end
+
+  def red_term_text(text)
+    "\033[0;31m#{text}\033[0m"
+  end
+
+  def blue_term_text(text)
+    "\033[0;36m#{text}\033[0m"
+  end
+
+  def yellow_term_text(text)
+    "\033[0;33m#{text}\033[0m"
+  end
+
+  def bold_term_text(text)
+    "\033[1m#{text}\033[0m"
+  end
+
+  def status(text)
+    STDERR.puts blue_term_text(text)
+  end
+
+  def warning(text)
+    STDERR.puts yellow_term_text(text)
+  end
+
+  def error(text)
+    STDERR.puts red_term_text(text)
+  end
+
+  def put_command(cmd, redact=nil)
+    if cmd.is_a?(String)
+      command_string = "+ #{cmd}"
+    else
+      command_string = "+ #{cmd.join(" ")}"
+    end
+    command_to_echo = command_string.clone
+    if redact
+      command_to_echo.sub! redact, "*" * redact.length
+    end
+    STDERR.puts command_to_echo
+  end
+
+  # Pass err=nil to suppress stderr.
+  def capture_stdout(cmd, err = STDERR)
+    if err.nil?
+      err = "/dev/null"
+    end
+    output, _ = Open3.capture2(*cmd, :err => err)
+    output
+  end
+
+  def run_inline(cmd, redact=nil)
+    put_command(cmd, redact)
+
+    # `system`, by design (?!), hides stderr when the command fails.
+    if ENV["PROJECTRB_USE_SYSTEM"] == "true"
+      if not system(*cmd)
+        exit $?.exitstatus
+      end
+    else
+      pid = spawn(*cmd)
+      Process.wait pid
+      if $?.exited?
+        if !$?.success?
+          exit $?.exitstatus
+        end
+      else
+        error "Command exited abnormally."
+        exit 1
+      end
+    end
+  end
+
+  def run_inline_swallowing_interrupt(cmd)
+    begin
+      run_inline cmd
+    rescue Interrupt
+    end
+  end
+
+  def run_or_fail(cmd, redact=nil)
+    put_command(cmd, redact)
+    Open3.popen3(*cmd) do |i, o, e, t|
+      i.close
+      if not t.value.success?
+        STDERR.write red_term_text(e.read)
+        exit t.value.exitstatus
+      end
+    end
+  end
+
+  def run(cmd)
+    Open3.popen3(*cmd) do |i, o, e, t|
+      i.close
+      t.value
+    end
+  end
+
+  def pipe(*cmds)
+    s = cmds.map { |x| x.join(" ") }
+    s = s.join(" | ")
+    STDERR.puts "+ #{s}"
+    Open3.pipeline(*cmds).each do |status|
+      unless status.success?
+        error "Piped command failed"
+        exit 1
+      end
+    end
+  end
+end
+
+def upgrade_self(_)
+  c = Common.new
+  Dir.chdir(File.dirname(__FILE__)) do
+    c.run_inline %W{git pull}
+  end
+  c.status "Tools upgraded to latest version."
+end
+
+Common.register_command({
+  :invocation => "upgrade-self",
+  :description => "Upgrades this project tool to the latest version.",
+  :fn => :upgrade_self,
+  :upgrade_self_command => true,
+})

--- a/utils/completion.bash
+++ b/utils/completion.bash
@@ -1,0 +1,8 @@
+_project_rb_complete() {
+  COMPREPLY=()
+  local word="${COMP_WORDS[COMP_CWORD]}"
+  local completions="$(./project.rb --cmplt "$COMP_CWORD" "${COMP_WORDS[@]}")"
+  COMPREPLY=( $(compgen -W "$completions" -- "$word") )
+}
+
+complete -f -F _project_rb_complete ./project.rb

--- a/utils/dockerhelper.rb
+++ b/utils/dockerhelper.rb
@@ -1,0 +1,45 @@
+class DockerHelper
+  attr :c
+
+  def initialize(common)
+    @c = common
+  end
+
+  def in_docker?()
+    File.exist?("/.dockerenv")
+  end
+
+  def requires_docker()
+    status = c.run %W{which docker}
+    unless status.success?
+      c.error "docker not installed."
+      STDERR.puts "Installation instructions:"
+      STDERR.puts "\n  https://www.docker.com/community-edition\n\n"
+      exit 1
+    end
+    status = c.run %W{docker info}
+    unless status.success?
+      c.error "`docker info` command failed."
+      STDERR.puts "This is usually a permissions problem. Try allowing your user to run docker\n"
+      STDERR.puts "without sudo:"
+      STDERR.puts "\n$ sudo usermod -aG docker #{ENV["USER"]}\n\n"
+      c.error "Note: You will need to log-in to a new shell before this change will take effect.\n"
+      exit 1
+    end
+  end
+
+  def image_exists?(name)
+    requires_docker
+    fmt = "{{.Repository}}:{{.Tag}}"
+    c.capture_stdout(%W{docker images --format #{fmt}}).include?(name)
+  end
+
+  def ensure_image(name)
+    requires_docker
+    if not image_exists?(name)
+      c.error "Missing docker image \"#{name}\". Pulling..."
+      c.run_inline(%W{docker pull #{name}})
+      c.status "Image \"#{name}\" pulled."
+    end
+  end
+end

--- a/utils/syncfiles.rb
+++ b/utils/syncfiles.rb
@@ -1,0 +1,204 @@
+require "open3"
+
+class SyncFiles
+  attr :c
+
+  def initialize(common)
+    @c = common
+  end
+
+  def is_fswatch_installed()
+    status = c.run %W{which fswatch}
+    return status.success?
+  end
+
+  def src_vol_name()
+    env = c.load_env
+    "#{env.namespace}-src"
+  end
+
+  def output_vol_name()
+    env = c.load_env
+    "#{env.namespace}-out"
+  end
+
+  def get_src_volume_mount()
+    if is_fswatch_installed
+      %W{-v #{src_vol_name}:/w}
+    else
+      %W{-v #{ENV["PWD"]}:/w}
+    end
+  end
+
+  def get_volume_mounts()
+    env = c.load_env
+    if env.static_file_dest
+      get_src_volume_mount + %W{-v #{output_vol_name}:/w/#{env.static_file_dest}}
+    else
+      get_src_volume_mount
+    end
+  end
+
+  def log_file_name()
+    ".rsync.log"
+  end
+
+  def log_message(s)
+    File.open(log_file_name, "a") do |file|
+      file.write s
+    end
+  end
+
+  def get_dest_path(src, dst)
+    if dst.nil?
+      dst = src
+    end
+    dst = dst.split(/\//).reverse.drop(1).reverse.join("/")
+    if not dst.empty?
+      dst = "/w/#{dst}"
+    else
+      dst = "/w"
+    end
+  end
+
+  def start_rsync_container()
+    env = c.load_env
+    c.docker.requires_docker
+    c.docker.ensure_image("tjamet/rsync")
+    cmd = %W{
+      docker run -d
+        --name #{env.namespace}-rsync
+        -v #{src_vol_name}:/w
+    }
+    if env.static_file_dest
+      cmd += %W{-v #{output_vol_name}:/w/#{env.static_file_dest}}
+    end
+    c.run_inline cmd + %W{-e DAEMON=docker tjamet/rsync}
+  end
+
+  def stop_rsync_container()
+    env = c.load_env
+    c.run_inline %W{docker rm -f #{env.namespace}-rsync}
+  end
+
+  def rsync_path(src, dst, log)
+    env = c.load_env
+    dst = get_dest_path(src, dst)
+    rsync_remote_shell = "docker exec -i"
+    cmd = %W{
+      rsync --blocking-io -azlv --delete -e #{rsync_remote_shell}
+        #{src}
+        #{env.namespace}-rsync:#{dst}
+    }
+    if log
+      Open3.popen3(*cmd) do |i, o, e, t|
+        i.close
+        if not t.value.success?
+          c.error e.read
+          exit t.value.exitstatus
+        end
+        log_message o.read
+      end
+    else
+      c.run_inline cmd
+    end
+  end
+
+  def link_static_file(src, dst)
+    env = c.load_env
+    cmd = %W{docker run --rm -w /w} + get_volume_mounts + %W{alpine ln -snf /w/#{src} /w/#{dst}}
+    c.run_inline cmd
+  end
+
+  def link_static_files()
+    env = c.load_env
+    threads = []
+    foreach_static_file do |path, entry|
+      threads << Thread.new do
+        link_static_file "#{path}/#{entry}", "#{env.static_file_dest}/#{entry}"
+      end
+    end
+    threads.each do |t|
+      t.join
+    end
+  end
+
+  def foreach_static_file()
+    env = c.load_env
+    Dir.foreach(env.static_file_src) do |entry|
+      unless [".", ".."].include?(entry)
+        yield env.static_file_src, entry
+      end
+    end
+  end
+
+  def watch_path(src, dst)
+    Open3.popen3(*%W{fswatch -o #{src}}) do |stdin, stdout, stderr, thread|
+      Thread.current["pid"] = thread.pid
+      stdin.close
+      stdout.each_line do |_|
+        rsync_path src, dst, true
+      end
+    end
+  end
+
+  def perform_initial_sync()
+    env = c.load_env
+    env.source_file_paths.each do |src_path|
+      # Copying using tar ensures the destination directories will be created.
+      c.pipe(
+        %W{env COPYFILE_DISABLE=1 tar -c #{src_path}},
+        %W{docker cp - #{env.namespace}-rsync:/w}
+      )
+      rsync_path src_path, nil, false
+    end
+    if env.static_file_src
+      c.pipe(
+        %W{env COPYFILE_DISABLE=1 tar -c #{env.static_file_src}},
+        %W{docker cp - #{env.namespace}-rsync:/w}
+      )
+      rsync_path env.static_file_src, nil, false
+    end
+  end
+
+  def start_watching_sync()
+    env = c.load_env
+    File.open(log_file_name, "w") {} # Create and truncate if exists.
+    paths_to_watch = env.source_file_paths
+    if env.static_file_src
+      paths_to_watch += [env.static_file_src]
+    end
+    paths_to_watch.each do |src_path|
+      thread = Thread.new { watch_path src_path, nil }
+      at_exit {
+        Process.kill("HUP", thread["pid"])
+        thread.join
+      }
+    end
+  end
+
+  def maybe_start_file_syncing()
+    system_name, _ = Open3.capture2("uname")
+    system_name.chomp!
+    env = c.load_env
+    if env.static_file_src
+      c.status "Linking static files..."
+      link_static_files
+    end
+    fswatch_installed = is_fswatch_installed
+    if system_name == "Darwin" and not fswatch_installed
+      c.error "fswatch is not installed."
+      STDERR.puts "File syncing will be extremely slow due to a performance problem in docker.\n" \
+        "Installing fswatch is highly recommended. Try:\n\n$ brew install fswatch\n\n"
+    end
+    if fswatch_installed
+      c.status "Starting rsync container..."
+      at_exit { stop_rsync_container }
+      start_rsync_container
+      c.status "Performing initial file sync..."
+      perform_initial_sync
+      start_watching_sync
+      c.status "Watching source files. See log at #{log_file_name}."
+    end
+  end
+end


### PR DESCRIPTION
Removes the dependency on https://github.com/dmohs/project-management to reduce the number of submodules and PRs that need to be made to make changes to our dev tooling.

The submodule was removed using `git rm utils` and restored by copying over the files.